### PR TITLE
Create the UnPoller Stack

### DIFF
--- a/pi-hosted_template/stack/unpoller-stack.yml
+++ b/pi-hosted_template/stack/unpoller-stack.yml
@@ -1,0 +1,37 @@
+version: "3"
+services:
+  influxdb:
+    container_name: up_influxdb
+    restart: unless-stopped
+    image: influxdb:1.8
+    networks:
+      UnPollerBridge:
+        ipv4_address: 172.15.0.3
+    ports:
+      - '8086:8086'
+    volumes:
+      - /portainer/Files/AppData/Config/unpollerinflux:/var/lib/influxdb
+    environment:
+      - INFLUXDB_DB=unifi
+      - INFLUXDB_ADMIN_USER=unifi
+      - INFLUXDB_ADMIN_PASSWORD=unifi
+
+  unpoller:
+    container_name: up-poller
+    restart: unless-stopped
+    image: golift/unifi-poller:latest
+    networks:
+      UnPollerBridge:
+        ipv4_address: 172.15.0.2
+    depends_on:
+      - influxdb
+    volumes:
+      - /portainer/Files/AppData/Config/unpoller:/etc/unifi-poller
+      
+networks:
+  UnPollerBridge:
+    ipam:
+      driver: default
+      config:
+        - subnet: "172.15.0.0/16"
+          gateway: "172.15.0.1"


### PR DESCRIPTION
This will create the needed containers and network with static IPs for this setup.

# Summary

Creation of an area and copying of the appropriate config file for the system.  It will then pull the yml file to create the stack.  Following a successful creation the user can then add 2 plugins to the raspi-monitoring grafana instance and integrate this new data source with it's associated dashboards.

# Why This Is Needed

This will allow the user the ability to monitor their Unifi Controller instance on the Pi along with the Raspi-Monitoring suite.

# What Changed

added the stack file to the /stack folder.
created the helper script to setup the appropriate config file and create the directory needed by the container
created the needed documenation on how to integrate the system into the existing grafana instance and get the 2 required plugins that will be needed to display correctly.

## Added

unpoller.yml
install-unpoller.sh

## Changed

N/A

## Fixed

N/A

## Removed

N/A

# Screenshots

![USG-UnPoller](https://user-images.githubusercontent.com/42878642/139700057-64e94ef3-1818-48d4-b50c-7773c05eac5a.PNG)

![UAP-unpoller](https://user-images.githubusercontent.com/42878642/139700166-16f8f5a4-fc9b-4002-a7b5-2c2b19cfdbe3.PNG)



# Checklist

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
- [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
- [ ] Does your submission pass tests?
- [ ] Have you linted your code locally prior to submission?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you updated documentation, as applicabl
